### PR TITLE
Disable mips_4kec on `main`

### DIFF
--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -66,6 +66,8 @@ jobs:
           # OpenWrt main (SNAPSHOT)
           - arch: arc_archs
             rel_branch: main
+          - arch: mips_4kec # https://lists.openwrt.org/pipermail/openwrt-devel/2025-August/044216.html
+            rel_branch: main
           # OpenWrt 24.10
           - arch: arc_archs
             rel_branch: openwrt-24.10


### PR DESCRIPTION
This arch has been killed upstream
https://lists.openwrt.org/pipermail/openwrt-devel/2025-August/044216.html