### PR TITLE
Update Makefile

### DIFF
--- a/meshtasticd-web/Makefile
+++ b/meshtasticd-web/Makefile
@@ -30,7 +30,7 @@ define Package/meshtasticd-web
   CATEGORY:=Network
   TITLE:=Meshtastic Daemon Web Interface
   URL:=http://github.com/meshtastic/firmware
-  DEPENDS:=meshtasticd
+  DEPENDS:=meshtasticd libmicrohttpd-ssl
 endef
 
 define Package/meshtasticd-web/description


### PR DESCRIPTION
A missing dependency will cause the following error on OpenWRT devices:
`Error starting Web Server framework, error number: 4`
The fix is to install libmicrohttpd-ssl.

Propose to add depend libmicrohttpd-ssl to package.