### PR TITLE
meshtasticd v2.7.26.54e0d8d

### DIFF
--- a/meshtasticd/Makefile
+++ b/meshtasticd/Makefile
@@ -6,16 +6,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meshtasticd
 # TODO renovate
-PKG_VERSION:=2.7.15
+PKG_VERSION:=2.7.26
 PKG_RELEASE:=1
 # TODO renovate
-PKG_SOURCE_VERSION:=v2.7.15.567b8ea
+PKG_SOURCE_VERSION:=v2.7.26.54e0d8d
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/meshtastic/firmware.git
 # TODO renovate?
-PKG_MIRROR_HASH:=494c4f4f84719237b08fc487c66c2c7a3b760b4b1d9a929358fcc801c67d8bcc
+PKG_MIRROR_HASH:=dc1d9843514b92590eaac0a329208b699e330522688215cfc8441c8945de4782
 PKG_BUILD_DEPENDS:= \
 	python3/host \
 	python-platformio/host \
@@ -117,7 +117,7 @@ endef
 
 define Package/meshtasticd/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.pio/build/buildroot/program $(1)/usr/bin/meshtasticd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.pio/build/buildroot/meshtasticd $(1)/usr/bin/meshtasticd
 
 	$(INSTALL_DIR) $(1)/etc/meshtasticd
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/bin/config-dist.yaml $(1)/etc/meshtasticd/config.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled `meshtasticd` package to a newer release.
  * Corrected the daemon installation path so the expected binary is installed properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->