### PR TITLE
Align platformio / ajsonrpc with upstream

### DIFF
--- a/depends/python-ajsonrpc/Makefile
+++ b/depends/python-ajsonrpc/Makefile
@@ -1,6 +1,4 @@
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-only
 
 include $(TOPDIR)/rules.mk
 
@@ -11,16 +9,11 @@ PKG_RELEASE:=1
 PYPI_NAME:=ajsonrpc
 PKG_HASH:=791bac18f0bf0dee109194644f151cf8b7ff529c4b8d6239ac48104a3251a19f
 
-PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
-HOST_BUILD_DEPENDS:= \
-	python3/host \
-	python-build/host \
-	python-installer/host \
-	python-wheel/host \
-	python-setuptools/host
+HOST_BUILD_DEPENDS:=python-setuptools/host
 PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include $(TOPDIR)/feeds/packages/lang/python/pypi.mk
@@ -33,13 +26,18 @@ define Package/python3-ajsonrpc
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=Python Library for implementing JSON-RPC 2.0
-  URL:=https://pypi.org/project/ajsonrpc
-  DEPENDS:=+python3-light +python3-asyncio +python3-logging
+  TITLE:=Async JSON-RPC 2.0 protocol + asyncio server
+  URL:=https://github.com/pavlov99/ajsonrpc
+  DEPENDS:= \
+    +python3-asyncio \
+    +python3-light \
+    +python3-logging
 endef
 
 define Package/python3-ajsonrpc/description
-Python JSON-RPC 2.0 implementation and asynchronous server powered by asyncio
+  Lightweight JSON-RPC 2.0 protocol implementation and asynchronous server
+  powered by asyncio. This library is a successor of json-rpc and written
+  by the same team.
 endef
 
 $(eval $(call Py3Package,python3-ajsonrpc))

--- a/depends/python-platformio/Makefile
+++ b/depends/python-platformio/Makefile
@@ -1,32 +1,35 @@
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-only
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-platformio
 PKG_VERSION:=6.1.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=platformio
-PYPI_SOURCE_NAME:=platformio
 PKG_HASH:=7b53eaa36fcba554411b669eab845626da7c4b90fa6aaee9fe9f1875d82f5f54
 
-PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
+PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 HOST_BUILD_DEPENDS:= \
-	python3/host \
+	python-ajsonrpc/host \
+	python3-bottle/host \
 	python-build/host \
-	python-installer/host \
-	python-pyserial/host \
 	python-click/host \
-	python-semantic-version/host \
-	python-requests/host \
-	python-tabulate/host \
+	python-installer/host \
+	python-marshmallow/host \
 	python-pyelftools/host \
-	python-ajsonrpc/host
+	python-pyserial/host \
+	python-requests/host \
+	python-semantic-version/host \
+	python-setuptools/host \
+	python-starlette/host \
+	python-tabulate/host \
+	python-uvicorn/host \
+	python-wsproto/host
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include $(TOPDIR)/feeds/packages/lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -35,25 +38,40 @@ include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-host-build.mk
 
 define Package/python3-platformio
-  SECTION:=meshtastic
-  CATEGORY:=Meshtastic
-  TITLE:=PlatformIO Host Tools
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=PlatformIO
   URL:=https://github.com/platformio/platformio-core
   DEPENDS:= \
-	+python3-light \
-	+python3-pyserial \
-	+python3-click \
-	+python3-semantic-version \
-	+python3-requests \
-	+python3-tabulate \
-	+python3-pyelftools \
-	+python3-ajsonrpc
+    +python3-ajsonrpc \
+    +python3-asyncio \
+    +python3-bottle \
+    +python3-click \
+    +python3-colorama \
+    +python3-ctypes \
+    +python3-light \
+    +python3-logging \
+    +python3-marshmallow \
+    +python3-multiprocessing \
+    +python3-openssl \
+    +python3-pyelftools \
+    +python3-pyserial \
+    +python3-requests \
+    +python3-semantic-version \
+    +python3-starlette \
+    +python3-tabulate \
+    +python3-urllib \
+    +python3-uuid \
+    +python3-uvicorn \
+    +python3-wsproto \
+    +python3-xml
 endef
 
 define Package/python3-platformio/description
-PlatformIO is an open-source build system for embedded development,
-supporting multiple platforms, frameworks, and boards
-with features like dependency management and IDE integration.
+  PlatformIO is a cross-platform, cross-architecture, multiple framework,
+  professional tool for embedded systems engineers and for software
+  developers who write applications for embedded products.
 endef
 
 $(eval $(call Py3Package,python3-platformio))


### PR DESCRIPTION
Upstream got ahead of us! :heart:

Pull changes back into here to use for backports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for the JSON-RPC Python library, including license, maintainer, project link, and a clearer multi-line description.
  * Refreshed PlatformIO packaging details by bumping its release version and expanding maintainer information.
  * Broadened PlatformIO’s declared dependency set and adjusted its package categorization/submenu and description for more accurate presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->